### PR TITLE
lcls: adding filter plotting functionality to plot.py, small changes to run.py and .ipynb for functionality, 

### DIFF
--- a/src/ufpdf_xfel_scripts/lcls/plots.py
+++ b/src/ufpdf_xfel_scripts/lcls/plots.py
@@ -2,6 +2,7 @@ import matplotlib
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.patches import Patch
 
 from ufpdf_xfel_scripts.lcls.run import find_nearest
 
@@ -576,7 +577,8 @@ def plot_time_resolved_window_map(
         aspect="auto",
         extent=extent,
         origin="lower",
-        cmap="viridis",
+        # cmap="viridis",
+        cmap="bwr",
     )
 
     ax.set_xlabel(axis_label)
@@ -701,3 +703,295 @@ def plot_morph_parameters(
 
     plt.tight_layout()
     plt.show()
+
+
+def plot_filter_metrics(run, n_bins=80):
+    """Plot diode (monitor2) and time_jitter distributions with filter
+    results when available.
+
+    Pane 1: diode histogram
+      light blue = Unfiltered Shots
+      red = Filtered Shots (if diode filter applied)
+      dashed lines: mean (black), median (blue), threshold (red)
+
+    Pane 2: timestamp (shifted, s) vs diode scatter
+      green = Unfiltered Shots
+      red = Filtered Shots (if diode filter applied)
+
+    Pane 3: time_jitter histogram
+      light blue = Unfiltered Shots
+      red = Filtered Shots (if time filter applied)
+      dashed red line = threshold cutoff (positive only)
+
+    Parameters
+    ----------
+    run : Run
+        Run object containing:
+          monitor2, time_jitter, timestamp, sample_name, run_number
+        And optional filter plotting state:
+          plt_filter_pre_monitor2, plt_filter_keep_diode,
+          plt_filter_cutoff_diode, plt_filter_pre_time,
+          plt_filter_keep_time, plt_filter_cutoff_time,
+          plt_filter_pre_timestamp.
+
+    n_bins : int
+        Number of bins used for the diode and time_jitter histograms.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The created figure (closed before return).
+    """
+    diode_filter_enabled = hasattr(run, "plt_filter_pre_monitor2") and hasattr(
+        run, "plt_filter_keep_diode"
+    )
+    if diode_filter_enabled:
+        diode_pre = run.plt_filter_pre_monitor2
+        diode_keep = run.plt_filter_keep_diode
+    else:
+        diode_pre = run.monitor2
+        diode_keep = np.ones_like(diode_pre, dtype=bool)
+
+    fig, (ax0, ax1, ax2) = plt.subplots(
+        3, 1, figsize=(9, 13), constrained_layout=True
+    )
+
+    # Pane 1
+    diode_pre_finite = diode_pre[np.isfinite(diode_pre)]
+    if not diode_pre_finite.size:
+        ax0.set_axis_off()
+        ax0.text(
+            0.5,
+            0.5,
+            "No finite monitor2 values",
+            transform=ax0.transAxes,
+            ha="center",
+            va="center",
+        )
+    else:
+        _, diode_edges = np.histogram(diode_pre_finite, bins=int(n_bins))
+        diode_centers = 0.5 * (diode_edges[:-1] + diode_edges[1:])
+        _, _, diode_patches = ax0.hist(
+            diode_pre_finite,
+            bins=diode_edges,
+            edgecolor="black",
+            linewidth=0.8,
+        )
+        for patch in diode_patches:
+            patch.set_facecolor("lightblue")
+        diode_cutoff = getattr(run, "plt_filter_cutoff_diode", None)
+        if diode_filter_enabled:
+            diode_filtered = diode_pre[~diode_keep]
+            diode_filtered = diode_filtered[np.isfinite(diode_filtered)]
+            if diode_filtered.size:
+                bad_bins = np.digitize(diode_filtered, diode_edges) - 1
+                bad_bins = np.clip(bad_bins, 0, len(diode_centers) - 1)
+                for idx in np.unique(bad_bins):
+                    diode_patches[int(idx)].set_facecolor("red")
+        diode_mean = float(np.mean(diode_pre_finite))
+        diode_median = float(np.median(diode_pre_finite))
+        ax0.axvline(diode_mean, linestyle="--", color="black", linewidth=1.2)
+        ax0.axvline(diode_median, linestyle="--", color="blue", linewidth=1.2)
+        if diode_filter_enabled and diode_cutoff is not None:
+            ax0.axvline(
+                float(diode_cutoff),
+                linestyle="--",
+                color="red",
+                linewidth=1.2,
+            )
+        q = getattr(run, "i0_percentile_threshold", None)
+        if diode_filter_enabled and q is not None:
+            thr_pct = f"{float(q):.2f}%"
+        else:
+            thr_pct = "None"
+        ax0.text(
+            0.01,
+            0.93,
+            (
+                f"threshold: {thr_pct}\n"
+                f"mean: {diode_mean:.4g}\n"
+                f"median: {diode_median:.4g}"
+            ),
+            transform=ax0.transAxes,
+            ha="left",
+            va="top",
+            fontsize=10,
+            bbox=dict(facecolor="white", alpha=0.7, edgecolor="none"),
+        )
+        unfiltered_patch = Patch(
+            facecolor="lightblue",
+            edgecolor="black",
+            label="Unfiltered Shots",
+        )
+        filtered_patch = Patch(
+            facecolor="red",
+            edgecolor="black",
+            label="Filtered Shots",
+        )
+        handles = [unfiltered_patch]
+        if diode_filter_enabled:
+            handles.append(filtered_patch)
+        ax0.legend(handles=handles, loc="upper right", frameon=True)
+        ax0.set_title(
+            "Diode filter" if diode_filter_enabled else "Diode distribution"
+        )
+        ax0.set_xlabel("2BmMon Diode Intensity (J)")
+        ax0.set_ylabel("Counts")
+
+    # Pane 2
+    t_ps = getattr(run, "plt_filter_pre_timestamp", None)
+    if t_ps is None:
+        t_ps = getattr(run, "timestamp", None)
+    use_time = t_ps is not None and len(t_ps) == len(diode_pre)
+    if use_time:
+        t_s = t_ps.astype(float) * 1e-12
+        finite_t = np.isfinite(t_s)
+        if finite_t.any():
+            t_s = t_s - t_s[finite_t][0]
+        else:
+            use_time = False
+    if not use_time:
+        t_s = np.arange(len(diode_pre), dtype=float)
+    if diode_filter_enabled:
+        h_keep = ax1.scatter(
+            t_s[diode_keep],
+            diode_pre[diode_keep],
+            s=6,
+            alpha=0.6,
+            color="green",
+            label="Unfiltered Shots",
+        )
+        h_filt = ax1.scatter(
+            t_s[~diode_keep],
+            diode_pre[~diode_keep],
+            s=6,
+            alpha=0.6,
+            color="red",
+            label="Filtered Shots",
+        )
+        ax1.legend(handles=[h_keep, h_filt], loc="upper right", frameon=True)
+    else:
+        h_all = ax1.scatter(
+            t_s,
+            diode_pre,
+            s=6,
+            alpha=0.6,
+            color="green",
+            label="Unfiltered Shots",
+        )
+        ax1.legend(handles=[h_all], loc="upper right", frameon=True)
+
+    ax1.set_xlabel("Time (s)" if use_time else "Index")
+    ax1.set_ylabel("2BmMon Diode Intensity (J)")
+    sample = getattr(run, "sample_name", "unknown")
+    run_number = getattr(run, "run_number", "unknown")
+    ax1.set_title(f"sample = {sample}, run = {run_number}")
+
+    # Pane 3
+    if hasattr(run, "plt_filter_pre_time"):
+        time_pre = run.plt_filter_pre_time
+    else:
+        time_pre = (
+            run.time_jitter
+            if getattr(run, "time_jitter", None) is not None
+            else None
+        )
+    if time_pre is None:
+        ax2.set_axis_off()
+        ax2.text(
+            0.5,
+            0.5,
+            "No time_jitter available",
+            transform=ax2.transAxes,
+            ha="center",
+            va="center",
+        )
+        plt.close(fig)
+        return fig
+    if diode_filter_enabled and len(time_pre) == len(diode_keep):
+        time_to_plot = time_pre[diode_keep]
+    else:
+        time_to_plot = time_pre
+    time_to_plot = time_to_plot[np.isfinite(time_to_plot)]
+    if not time_to_plot.size:
+        ax2.set_axis_off()
+        ax2.text(
+            0.5,
+            0.5,
+            "No finite time_jitter values",
+            transform=ax2.transAxes,
+            ha="center",
+            va="center",
+        )
+        plt.close(fig)
+        return fig
+    _, time_edges = np.histogram(time_to_plot, bins=int(n_bins))
+    time_centers = 0.5 * (time_edges[:-1] + time_edges[1:])
+    _, _, time_patches = ax2.hist(
+        time_to_plot,
+        bins=time_edges,
+        edgecolor="black",
+        linewidth=0.8,
+    )
+    for patch in time_patches:
+        patch.set_facecolor("lightblue")
+    time_cutoff = getattr(run, "plt_filter_cutoff_time", None)
+    time_filter_applied = hasattr(run, "plt_filter_keep_time")
+    time_filter_applied = time_filter_applied and time_cutoff is not None
+    h_cut = None
+    if time_filter_applied:
+        cut_tt = float(time_cutoff)
+        for i, patch in enumerate(time_patches):
+            if float(time_centers[i]) > cut_tt:
+                patch.set_facecolor("red")
+        h_cut = ax2.axvline(
+            cut_tt,
+            linestyle="--",
+            color="red",
+            linewidth=1.2,
+            label=f"cut={cut_tt:.4g} ps",
+        )
+    t_mean = float(np.mean(time_to_plot))
+    t_median = float(np.median(time_to_plot))
+    if time_filter_applied:
+        thr_ps = f"{float(time_cutoff):.4g}"
+    else:
+        thr_ps = "None"
+    ax2.text(
+        0.01,
+        0.93,
+        (
+            f"threshold (ps): {thr_ps}\n"
+            f"mean (ps): {t_mean:.3f}\n"
+            f"median (ps): {t_median:.3f}"
+        ),
+        transform=ax2.transAxes,
+        ha="left",
+        va="top",
+        fontsize=10,
+        bbox=dict(facecolor="white", alpha=0.7, edgecolor="none"),
+    )
+    unfiltered_patch = Patch(
+        facecolor="lightblue",
+        edgecolor="black",
+        label="Unfiltered Shots",
+    )
+    filtered_patch = Patch(
+        facecolor="red",
+        edgecolor="black",
+        label="Filtered Shots",
+    )
+    legend_handles = [unfiltered_patch]
+    if time_filter_applied:
+        legend_handles.append(filtered_patch)
+        if h_cut is not None:
+            legend_handles.append(h_cut)
+    ax2.legend(handles=legend_handles, loc="upper right", frameon=True)
+    ax2.set_xlabel("Time Offset (ps)")
+    ax2.set_ylabel("Counts")
+    ax2.set_title(
+        "Time offset (filtered)" if time_filter_applied else "Time offset"
+    )
+
+    plt.close(fig)
+    return fig

--- a/src/ufpdf_xfel_scripts/lcls/plots.py
+++ b/src/ufpdf_xfel_scripts/lcls/plots.py
@@ -563,35 +563,33 @@ def plot_time_resolved_window_map(
 
         FOM_map[:, i_c] = values
 
-    fig, ax = plt.subplots(figsize=(9, 6))
+    with mpl.rc_context({"image.cmap": "bwr"}):
+        fig, ax = plt.subplots(figsize=(9, 6))
 
-    extent = [
-        centers[0],
-        centers[-1],
-        delay_times[0],
-        delay_times[-1],
-    ]
+        extent = [
+            centers[0],
+            centers[-1],
+            delay_times[0],
+            delay_times[-1],
+        ]
 
-    im = ax.imshow(
-        FOM_map,
-        aspect="auto",
-        extent=extent,
-        origin="lower",
-        # cmap="viridis",
-        cmap="bwr",
-    )
+        im = ax.imshow(
+            FOM_map,
+            aspect="auto",
+            extent=extent,
+            origin="lower",
+        )
 
-    ax.set_xlabel(axis_label)
-    ax.set_ylabel("Delay (ps)")
-    ax.set_title(
-        f"{data_label} time-resolved window map\n"
-        f"metric={metric}, width={width}, run={run.run_number}"
-    )
+        ax.set_xlabel(axis_label)
+        ax.set_ylabel("Delay (ps)")
+        ax.set_title(
+            f"{data_label} time-resolved window map\n"
+            f"metric={metric}, width={width}, run={run.run_number}"
+        )
 
-    plt.colorbar(im, ax=ax, label=metric)
-
-    plt.tight_layout()
-    plt.show()
+        plt.colorbar(im, ax=ax, label=metric)
+        plt.tight_layout()
+        plt.show()
 
 
 def plot_morph_parameters(

--- a/src/ufpdf_xfel_scripts/lcls/run.py
+++ b/src/ufpdf_xfel_scripts/lcls/run.py
@@ -542,6 +542,8 @@ class Run:
         # filter 1: monitor2 (diode)
         if self.i0_percentile_threshold is not None:
             self.plt_filter_pre_monitor2 = self.monitor2.copy()
+            if self.timestamp is not None:  # timestamp used in filter 1
+                self.plt_filter_pre_timestamp = self.timestamp.copy()
             if not (0.0 < float(self.i0_percentile_threshold) < 100.0):
                 raise ValueError(
                     "i0_percentile_threshold must be in (0, 100)."
@@ -594,8 +596,6 @@ class Run:
         if float(self.jitter_threshold_fs) <= 0.0:
             raise ValueError("jitter_threshold_fs must be > 0 or None.")
         self.plt_filter_pre_time = self.time_jitter.copy()
-        if self.timestamp is not None:
-            self.plt_filter_pre_timestamp = self.timestamp.copy()
         jitter_negative_count = int(
             np.sum(self.time_jitter[finite_time_mask] < 0.0)
         )

--- a/src/ufpdf_xfel_scripts/lcls/scripts/preview_single_run.ipynb
+++ b/src/ufpdf_xfel_scripts/lcls/scripts/preview_single_run.ipynb
@@ -18,7 +18,6 @@
     "                                           plot_gr_function,\n",
     "                                           plot_time_resolved_window_map,\n",
     "                                           plot_morph_parameters,\n",
-    "                                           plot_morph_parameters,\n",
     "                                           plot_filter_metrics)"
    ]
   },

--- a/src/ufpdf_xfel_scripts/lcls/scripts/preview_single_run.ipynb
+++ b/src/ufpdf_xfel_scripts/lcls/scripts/preview_single_run.ipynb
@@ -17,7 +17,9 @@
     "                                           plot_reference_comparison,\n",
     "                                           plot_gr_function,\n",
     "                                           plot_time_resolved_window_map,\n",
-    "                                           plot_morph_parameters)"
+    "                                           plot_morph_parameters,\n",
+    "                                           plot_morph_parameters,\n",
+    "                                           plot_filter_metrics)"
    ]
   },
   {
@@ -58,8 +60,8 @@
     "total = [0,1,2,3,4,5,6,7,8,9,10,11,12]\n",
     "\n",
     "# setup for roi\n",
-    "q_min =2.2 # I(q) figure of merit (fom)\n",
-    "q_max =2.7 # I(q) fom\n",
+    "q_min = 4.3 # I(q) figure of merit (fom)\n",
+    "q_max = 4.5 # I(q) fom\n",
     "r_min_fom = 6 # G(r) fom \n",
     "r_max_fom = 7 # G(r) fom\n",
     "\n",
@@ -105,17 +107,19 @@
    "outputs": [],
    "source": [
     "# Run:\n",
-    "run_number = 211\n",
+    "run_number = 185\n",
     "background_number = 1\n",
-    "sample_name = 'NSWS'\n",
-    "sample_composition = 'Na11SnPS12'\n",
+    "sample_name = 'Bi'\n",
+    "sample_composition = 'Bi'\n",
     "azimuthal_selector = total # List of integers, e.g., [1,6,13]. Pre-defined options are vertical, horizontal, total.\n",
     "number_of_static_samples = 11   # only needed for static runs, will be ignored otherwise\n",
-    "verbose = False\n",
+    "verbose = True\n",
     "plot_monitor_normalizations = False\n",
     "# delay motor name used for this run\n",
     "delay_motor = \"mfx_lxt_fast2\"\n",
-    "#delay_motor = \"lxt_ttx\""
+    "#delay_motor = \"lxt_ttx\"\n",
+    "i0_percentile_threshold = 5 # percentile threshold for i0 filter. Set to None to disable. \n",
+    "jitter_threshold_fs = 250 # cutoff threshold in (ps). Set to None to disable. "
    ]
   },
   {
@@ -151,6 +155,9 @@
     "                 pdf_rmin=pdf_rmin,\n",
     "                 pdf_rmax=pdf_rmax,\n",
     "                 azimuthal_selector=azimuthal_selector,\n",
+    "                 verbose=verbose,\n",
+    "                 i0_percentile_threshold=i0_percentile_threshold,\n",
+    "                 jitter_threshold_fs=jitter_threshold_fs,\n",
     "                 )\n",
     "morph_parameters = run_object.morph_parameters # Dictionary with fitted morph parameters. The key is the delay."
    ]
@@ -159,6 +166,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot shot filter metrics\n",
+    "plot_filter_metrics(run_object)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -289,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/ufpdf_xfel_scripts/lcls/scripts/preview_single_run.ipynb
+++ b/src/ufpdf_xfel_scripts/lcls/scripts/preview_single_run.ipynb
@@ -118,7 +118,7 @@
     "delay_motor = \"mfx_lxt_fast2\"\n",
     "#delay_motor = \"lxt_ttx\"\n",
     "i0_percentile_threshold = 5 # percentile threshold for i0 filter. Set to None to disable. \n",
-    "jitter_threshold_fs = 250 # cutoff threshold in (ps). Set to None to disable. "
+    "jitter_threshold_fs = 250 # cutoff threshold in (fs). Set to None to disable. "
    ]
   },
   {


### PR DESCRIPTION
**Primary Functionality**
Added plot_filter_metrics() function to plots.py, this function creates a 3-pane plot with the following subplots:
- Subplot 1: diode histogram
  - light blue = Unfiltered Shots
  - red = Filtered Shots (if diode filter applied)
  - dashed lines: mean (black), median (blue), threshold (red)

- Subplot 2: timestamp (shifted, s) vs diode scatter
  - green = Unfiltered Shots
  - red = Filtered Shots (if diode filter applied)

- Subplot 3: time_jitter histogram
  - light blue = Unfiltered Shots
  - red = Filtered Shots (if time filter applied)
  - dashed red line = threshold cutoff (positive only)

**Additional Modifications**
- Updated run.py error to enable subplot 2 time-axis to be plotted in seconds (s)
- Small modification to plot_time_resolved_window_map() default colormap based on Sam Marks' preference
- Updates to preview_single_run.ipynb: 
  - Added plot_filter_metrics import in import statement
  - Included i0_percentile_threshold, and jitter_threshold_fs in the settings cell
  - Added cell for plot_filter_metrics
  - Updated use case example for functional use case with plot_filter_metrics, previous use case was not yet processed.